### PR TITLE
Don't manage package vim-base for Suse 11, 12

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,6 @@ class vim (
         '11', '12': {
           $default_package_list = [
             'vim',
-            'vim-base',
             'vim-data',
           ]
         }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,12 +30,12 @@ describe 'vim' do
     'suse11' =>
       { :osfamily => 'Suse',
         :release  => '11',
-        :packages => ['vim','vim-base','vim-data'],
+        :packages => ['vim','vim-data'],
       },
     'suse12' =>
       { :osfamily => 'Suse',
         :release  => '12',
-        :packages => ['vim','vim-base','vim-data'],
+        :packages => ['vim','vim-data'],
       },
     'solaris10' =>
       { :osfamily => 'Solaris',


### PR DESCRIPTION
Package 'vim-base' is not available on SLES12. It is automatically pulled
in as a dependency on SLES11 by package 'vim'

This has not been verified to work correctly on OpenSuSE though. Would be perfect if someone could verify it.
